### PR TITLE
Fix return value of seestar_cqltypes:decode_map/5

### DIFF
--- a/src/seestar_cqltypes.erl
+++ b/src/seestar_cqltypes.erl
@@ -119,7 +119,7 @@ decode_map(KeyType, ValueType, Size, Data, Dict) ->
     {ValueBytes, Rest1} = seestar_types:decode_short_bytes(Rest0),
     Key = decode_value(KeyType, KeyBytes),
     Value = decode_value(ValueType, ValueBytes),
-    decode_map(KeyType, ValueType, Size - 1, Rest1, dict:append(Key, Value, Dict)).
+    decode_map(KeyType, ValueType, Size - 1, Rest1, dict:store(Key, Value, Dict)).
 
 decode_set(Type, Data) ->
     {Size, Rest} = seestar_types:decode_short(Data),


### PR DESCRIPTION
Seestar expects following structure for encoding as value for Cassandra map:
dict:from_list([{Key1, Value1}, {Key2, Value2}, ...]).
When decoding Cassandra map it returns this structure:
dict:from_list([{Key1, [Value1]}, {Key2, [Value2]}, ...]).
Goal of this fix is to make seestar accept same value for encoding, as
it returns from decoding.
