### PR TITLE
Optimize decode of large responses

### DIFF
--- a/src/seestar_frame.erl
+++ b/src/seestar_frame.erl
@@ -69,15 +69,16 @@ encode_flags(Flags) ->
 encode_flag(compression) -> ?COMPRESSION;
 encode_flag(tracing)     -> ?TRACING.
 
--spec decode(binary()) -> {[frame()], binary()}.
+-spec decode(binary()) -> {[frame()], binary(), integer() | undefined}.
 decode(Stream) ->
     decode(Stream, []).
-
 decode(<<16#81, Flags, ID/signed, Op, Size:32, Body:Size/binary, Rest/binary>>, Acc) ->
     Frame = #frame{id = ID, flags = decode_flags(Flags), opcode = Op, body = Body},
     decode(Rest, [Frame|Acc]);
+decode(<<16#81, _Flags, _ID/signed, _Op, Size:32, _Rest/binary>> = Stream, Acc) ->
+    {lists:reverse(Acc), Stream, Size + 8};
 decode(Stream, Acc) ->
-    {lists:reverse(Acc), Stream}.
+    {lists:reverse(Acc), Stream, undefined}.
 
 decode_flags(Byte) ->
     F = fun(Mask, Flags) when Byte band Mask =:= Mask ->


### PR DESCRIPTION
Each time Seestar receives part of response body it appends it to binary
accumulator. When response is quite large these appends creates big
performance problem.
Reason is that each append means creating new larger binary and copying
content from previous binary accumulator (which can be quite large).
Complexity of such operation is O(n^2), when 'n' represents size of
data.

New approach append buffers only till point, where size of request will
be found. Since this point all pieces will be stored in iolist, till all
request data will be available. Then iolist will be converted to binary
and processed as previously.
Complexity of this operation is O(n).
In one of our example processing time (including Cassandra response
time) drops from 13 minutes to 30 seconds for 55MB response.
