### PR TITLE
Resolve deprecation warnings added in OTP 17

### DIFF
--- a/src/seestar_cqltypes.erl
+++ b/src/seestar_cqltypes.erl
@@ -22,7 +22,7 @@
                   timeuuid | inet.
 -type decimal() :: {Unscaled :: integer(), Scale :: integer()}.
 -type value() :: null | integer() | binary() | boolean() | float() | inet:ip_address() |
-                 decimal() | list() | dict() | set().
+                 decimal() | list() | dict:dict() | sets:set().
 -export_type([type/0, value/0]).
 
 %% -------------------------------------------------------------------------

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -52,7 +52,7 @@
          sock :: inet:socket(),
          buffer :: seestar_buffer:buffer(),
          free_ids :: [seestar_frame:stream_id()],
-         backlog = queue:new() :: queue(),
+         backlog = queue:new() :: queue:queue(),
          reqs :: ets:tid()}).
 
 %% -------------------------------------------------------------------------


### PR DESCRIPTION
When compiling with erlang 17, we get deprecation errors.
Fixes:

```
==> seestar (compile)
Compiling src/seestar_cqltypes.erl failed:
src/seestar_cqltypes.erl:25: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/seestar_cqltypes.erl:25: type set/0 is deprecated and will be removed in OTP 18.0; use use sets:set/0 or preferably sets:set/1
ERROR: compile failed while processing /Users/phamilton/repos/api_segments/deps/seestar: rebar_abort
```

and

```
==> seestar (compile)
Compiling src/seestar_session.erl failed:
src/seestar_session.erl:55: type queue/0 is deprecated and will be removed in OTP 18.0; use use queue:queue/0 or preferably queue:queue/1
ERROR: compile failed while processing /Users/phamilton/repos/api_segments/deps/seestar: rebar_abort
```
