### PR TITLE
Forward Cassandra events to a listener pid

### DIFF
--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -135,14 +135,11 @@ decode(?SUPPORTED, Body) ->
 
 decode(?EVENT, Body) ->
     {EventType, Rest} = seestar_types:decode_string(Body),
-    case EventType of
-        ?TOPOLOGY_CHANGE ->
-            decode_topology_change(Rest);
-        ?STATUS_CHANGE ->
-            decode_status_change(Rest);
-        ?SCHEMA_CHANGE ->
-            decode_schema_change(Rest)
-    end;
+    #event{event = case EventType of
+                       ?TOPOLOGY_CHANGE -> decode_topology_change(Rest);
+                       ?STATUS_CHANGE -> decode_status_change(Rest);
+                       ?SCHEMA_CHANGE -> decode_schema_change(Rest)
+                   end};
 
 decode(?RESULT, Body) ->
     {Kind, Rest} = seestar_types:decode_int(Body),

--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -37,6 +37,10 @@
 %% event.
 -define(EVENT, 16#0C).
 
+-define(TOPOLOGY_CHANGE, <<"TOPOLOGY_CHANGE">>).
+-define(STATUS_CHANGE, <<"STATUS_CHANGE">>).
+-define(SCHEMA_CHANGE, <<"SCHEMA_CHANGE">>).
+
 -type outgoing() :: #startup{}
                   | #credentials{}
                   | #options{}
@@ -128,6 +132,17 @@ decode(?SUPPORTED, Body) ->
     {KVPairs, _} = seestar_types:decode_string_multimap(Body),
     #supported{versions = proplists:get_value(?VERSION, KVPairs),
                compression = proplists:get_value(?COMPRESSION, KVPairs)};
+
+decode(?EVENT, Body) ->
+    {EventType, Rest} = seestar_types:decode_string(Body),
+    case EventType of
+        ?TOPOLOGY_CHANGE ->
+            decode_topology_change(Rest);
+        ?STATUS_CHANGE ->
+            decode_status_change(Rest);
+        ?SCHEMA_CHANGE ->
+            decode_schema_change(Rest)
+    end;
 
 decode(?RESULT, Body) ->
     {Kind, Rest} = seestar_types:decode_int(Body),
@@ -247,6 +262,20 @@ decode_prepared(Body) ->
     {ID, Rest} = seestar_types:decode_short_bytes(Body),
     {Meta, _} = decode_metadata(Rest),
     #prepared{id = ID, metadata = Meta}.
+
+decode_topology_change(Body) ->
+    {Change, Rest} = seestar_types:decode_string(Body),
+    {{Address, Port}, _} = seestar_types:decode_inet(Rest),
+    #topology_change{change = list_to_atom(string:to_lower(binary_to_list(Change))),
+                     ip = Address,
+                     port = Port}.
+
+decode_status_change(Body) ->
+    {Change, Rest} = seestar_types:decode_string(Body),
+    {{Address, Port}, _} = seestar_types:decode_inet(Rest),
+    #status_change{change = list_to_atom(string:to_lower(binary_to_list(Change))),
+                   ip = Address,
+                   port = Port}.
 
 decode_schema_change(Body) ->
     {Change, Rest} = seestar_types:decode_string(Body),

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -29,6 +29,7 @@
 -export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2,
          code_change/3]).
 
+-type host() :: string() | inet:ip_address().
 -type credentials() :: [{string() | binary(), string() | binary()}].
 -type events() :: [topology_change | status_change | schema_change].
 -type client_option() :: {keyspace, string() | binary()}
@@ -51,7 +52,7 @@
          sync = true :: boolean()}).
 
 -record(st,
-        {host :: inet:hostname(),
+        {host :: host(),
          transport :: tcp | ssl,
          sock :: inet:socket() | ssl:sslsocket(),
          buffer :: seestar_buffer:buffer(),
@@ -65,13 +66,13 @@
 %% -------------------------------------------------------------------------
 
 %% @equiv start_link(Host, Post, [])
--spec start_link(inet:hostname(), inet:port_number()) ->
+-spec start_link(host(), inet:port_number()) ->
     any().
 start_link(Host, Port) ->
     start_link(Host, Port, []).
 
 %% @equiv start_link(Host, Post, ClientOptions, [])
--spec start_link(inet:hostname(), inet:port_number(), [client_option()]) ->
+-spec start_link(host(), inet:port_number(), [client_option()]) ->
     any().
 start_link(Host, Port, ClientOptions) ->
     start_link(Host, Port, ClientOptions, []).
@@ -81,7 +82,7 @@ start_link(Host, Port, ClientOptions) ->
 %% By default it will connect on plain tcp. If you want to connect using ssl, pass
 %% {ssl, [ssl_option()]} in the ConnectOptions
 %% @end
--spec start_link(inet:hostname(), inet:port_number(), [client_option()], [connect_option()]) ->
+-spec start_link(host(), inet:port_number(), [client_option()], [connect_option()]) ->
     {ok, pid()} | {error, any()}.
 start_link(Host, Port, ClientOptions, ConnectOptions) ->
      case gen_server:start_link(?MODULE, [Host, Port, ConnectOptions], []) of

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -344,7 +344,10 @@ process_frames([Frame|Frames], St) ->
 process_frames([], St) ->
     process_backlog(St).
 
-handle_event(_Frame, St) ->
+handle_event(Frame, St) ->
+    Op = seestar_frame:opcode(Frame),
+    Body = seestar_frame:body(Frame),
+    io:format("Whooa. Event! Decoded:\n~p\n", [seestar_messages:decode(Op, Body)]),
     St.
 
 handle_response(Frame, St) ->

--- a/src/seestar_types.erl
+++ b/src/seestar_types.erl
@@ -139,12 +139,12 @@ decode_inet(Data) ->
     Addr = case Size of
         4 ->
             % ipv4 / inet
-            <<A:8, B:8, C:8, D:8>> = AddrBytes,
-            {A, B, C, D};
+            <<N1:8, N2:8, N3:8, N4:8>> = AddrBytes,
+            {N1, N2, N3, N4};
         16 ->
             % ipv6 / 'inet6'
-            <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>> = AddrBytes,
-            {A, B, C, D, E, F, G, H}
+            <<K1:16, K2:16, K3:16, K4:16, K5:16, K6:16, K7:16, K8:16>> = AddrBytes,
+            {K1, K2, K3, K4, K5, K6, K7, K8}
     end,
     {{Addr, Port}, Rest3}.
 


### PR DESCRIPTION
Seestar already supports subscribing to server events, and the function exists to handle them as they arrive.

This patch implements decoding topology and status change events; the schema change event decoder exists.

seestar_session now tracks an event listener pid in its state. Incoming events are forwarded to this pid, if it is defined. This follows the style of reply_async, and offloads the protocol decoding to the event listener process by message passing an anonymous function.

Users configure the session's event listener with seestar_session:set_event_listener/2. I did not add support for configuring the listener as a part of start_link. A nice way to do so didn't jump out at me, as the event listener doesn't properly belong among ClientOptions or ConnectOptions.

Tested against cassandra 2.0.6.

No attempt was made at unit test coverage ... yet.