### PR TITLE
Change to canonical edown source

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
             {platform_define, "^R1[56]", only_builtin_types}]}. %% Ref: OTP commit b66e75c]}.
 
 {deps,
- [{edown, ".*", {git, "https://github.com/esl/edown.git", {branch, "master"}}}]}.
+ [{edown, ".*", {git, "https://github.com/uwiger/edown", {branch, "master"}}}]}.
 
 {edoc_opts,
  [{doclet, edown_doclet},


### PR DESCRIPTION
Current version of edown fails compilation under OTP 18. See esl/edown#32
