### PR TITLE
Protocol v4 and v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 # Docker runs on Trusty planform (the new one)
 install:
     - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
-    - ./wait_for_cassandra.sh
+    - ./wait_for_cassandra.sh || docker logs cassandra
 script:
     - ./rebar skip_deps=true eunit -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: erlang
+sudo: required
+# Install cassandra
+# Standard Travis cassandra is 2.0.9
+# Docker runs on Trusty planform (the new one)
+install:
+    - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+    - sudo apt-get update -qq
+    - sudo apt-get -qq -y install g++-4.8
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+script:
+    - ./rebar skip_deps=true compile
+    - ./rebar skip_deps=true eunit -v
+
+services:
+        - docker
+
+otp_release:
+    - R16B03
+    - 17.5
+    - 18.1
+
+env:
+    - CASSANDRA_VERSION=2.1
+    - CASSANDRA_VERSION=3.1
+    - CASSANDRA_VERSION=3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ sudo: required
 # Docker runs on Trusty planform (the new one)
 install:
     - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
-    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-    - sudo apt-get update -qq
-    - sudo apt-get -qq -y install g++-4.8
-    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 script:
     - ./rebar skip_deps=true compile
     - ./rebar skip_deps=true eunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 # Docker runs on Trusty planform (the new one)
 install:
     - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
+    - ./wait_for_cassandra.sh
 script:
     - ./rebar skip_deps=true eunit -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: required
 install:
     - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
 script:
-    - ./rebar skip_deps=true compile
     - ./rebar skip_deps=true eunit -v
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 # Standard Travis cassandra is 2.0.9
 # Docker runs on Trusty planform (the new one)
 install:
-    - docker run -d --net=host -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
+    - docker run -d -p 9042:9042 -e MAX_HEAP_SIZE=128M -e HEAP_NEWSIZE=64M --name=cassandra cassandra:${CASSANDRA_VERSION}
     - ./wait_for_cassandra.sh || docker logs cassandra
 script:
     - ./rebar skip_deps=true eunit -v

--- a/include/builtin_types.hrl
+++ b/include/builtin_types.hrl
@@ -5,5 +5,5 @@
 -else.
     -type dict_t() :: dict:dict().
     -type queue_t() :: queue:queue().
-    -type set_t() :: set:set().
+    -type set_t() :: sets:set().
 -endif.

--- a/include/constants.hrl
+++ b/include/constants.hrl
@@ -27,6 +27,9 @@
 -define(TRUNCATE_ERROR,    16#1003).
 -define(WRITE_TIMEOUT,     16#1100).
 -define(READ_TIMEOUT,      16#1200).
+-define(READ_FAILURE,      16#1300).
+-define(FUNCTION_FAILURE,  16#1400).
+-define(WRITE_FAILURE,     16#1500).
 
 %% 2xx: problem validating the request
 -define(SYNTAX_ERROR,      16#2000).

--- a/src/seestar_cqltypes.erl
+++ b/src/seestar_cqltypes.erl
@@ -254,8 +254,23 @@ decode_type(Data) ->
             {{map, KeyType, ValueType}, Rest2};
         16#22 ->
             {Subtype, Rest1} = decode_type(Rest0),
-            {{set, Subtype}, Rest1}
+            {{set, Subtype}, Rest1};
+        16#30 ->
+            erlang:error({todo, udt});
+        16#31 ->
+            {N, Rest1} = seestar_types:decode_short(Rest0),
+            {Types, Rest2} = decode_types(N, Rest1),
+            {{type, Types}, Rest2}
     end.
+
+decode_types(N, Data) ->
+    decode_types(N, Data, []).
+
+decode_types(0, Data, Types) ->
+    {lists:reverse(Types), Data};
+decode_types(N, Data, Types) when N > 0 ->
+    {Type, Rest0} = decode_type(Data),
+    decode_types(N-1, Rest0, [Type|Types]).
 
 code_to_type(16#01) -> ascii;
 code_to_type(16#02) -> bigint;
@@ -272,4 +287,8 @@ code_to_type(16#0C) -> uuid;
 code_to_type(16#0D) -> varchar;
 code_to_type(16#0E) -> varint;
 code_to_type(16#0F) -> timeuuid;
-code_to_type(16#10) -> inet.
+code_to_type(16#10) -> inet;
+code_to_type(16#11) -> date;
+code_to_type(16#12) -> time;
+code_to_type(16#13) -> smallint;
+code_to_type(16#14) -> tinyint.

--- a/src/seestar_frame.erl
+++ b/src/seestar_frame.erl
@@ -62,7 +62,7 @@ body(Frame) ->
 
 -spec encode(frame()) -> binary().
 encode(#frame{id = ID, flags = Flags, opcode = Op, body = Body}) ->
-    <<16#01, (encode_flags(Flags)), ID/signed, Op, (size(Body)):32, Body/binary>>.
+    <<16#04, (encode_flags(Flags)), ID:16/signed, Op, (size(Body)):32, Body/binary>>.
 
 encode_flags(Flags) ->
     lists:foldl(fun(Flag, Byte) -> encode_flag(Flag) bor Byte end, 0, Flags).
@@ -71,7 +71,7 @@ encode_flag(compression) -> ?COMPRESSION;
 encode_flag(tracing)     -> ?TRACING.
 
 -spec pending_size(binary()) -> pos_integer().
-pending_size(<<16#81, _Flags, _ID/signed, _Op, Size:32, _/binary>>) ->
+pending_size(<<16#84, _Flags, _ID:16/signed, _Op, Size:32, _/binary>>) ->
     Size + 8;
 pending_size(_) ->
     undefined.
@@ -79,7 +79,7 @@ pending_size(_) ->
 -spec decode(binary()) -> {[frame()], binary()}.
 decode(Stream) ->
     decode(Stream, []).
-decode(<<16#81, Flags, ID/signed, Op, Size:32, Body:Size/binary, Rest/binary>>, Acc) ->
+decode(<<16#84, Flags, ID:16/signed, Op, Size:32, Body:Size/binary, Rest/binary>>, Acc) ->
     Frame = #frame{id = ID, flags = decode_flags(Flags), opcode = Op, body = Body},
     decode(Rest, [Frame|Acc]);
 decode(Stream, Acc) ->

--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -199,13 +199,13 @@ decode_unprepared(Data) ->
     {ID, _} = seestar_types:decode_short_bytes(Data),
     #unprepared{id = ID}.
 
-decode_read_failure(Data) ->
+decode_read_failure(_Data) ->
     ok.
 
-decode_function_failure(Data) ->
+decode_function_failure(_Data) ->
     ok.
 
-decode_write_failure(Data) ->
+decode_write_failure(_Data) ->
     ok.
 
 %% -------------------------------------------------------------------------

--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -48,7 +48,10 @@
                   | #'query'{}
                   | #prepare{}
                   | #execute{}
-                  | #register{}.
+                  | #register{}
+                  | #batch{}
+                  | #batch_query{}
+                  | #batch_execute{}.
 
 -type incoming() :: #error{}
                   | #ready{}

--- a/src/seestar_messages.hrl
+++ b/src/seestar_messages.hrl
@@ -37,6 +37,19 @@
          variables :: [binary()],
          consistency = one :: atom()}).
 
+-record(batch_query,
+        {query :: binary()}).
+
+-record(batch_execute,
+        {id :: binary(),
+         types = [] :: [seestar_cqltypes:type()],
+         values = [] :: [seestar_cqltypes:value()]}).
+
+-record(batch,
+        {type :: logged | unlogged | counter,
+         queries :: [#batch_query{} | #batch_execute{}],
+         consistency = one :: atom()}).
+
 -record(register,
         {event_types = [] :: [topology_change | status_change | schema_change]}).
 

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -400,6 +400,7 @@ handle_info(Info, St) ->
     {stop, {unexpected_info, Info}, St}.
 
 process_frames([Frame|Frames], St) ->
+    print_warnings(Frame),
     process_frames(Frames,
                    case seestar_frame:id(Frame) of
                        -1 -> handle_event(Frame, St);
@@ -467,3 +468,11 @@ process_backlog(#st{backlog = Backlog, free_ids = FreeIDs} = St) ->
 %% @private
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+print_warnings(Frame) ->
+    Warnings = seestar_frame:warnings(Frame),
+    [print_warning(Frame, Warning) || Warning <- Warnings].
+
+print_warning(Frame, Warning) ->
+    error_logger:warning_msg("issue=cassandra_warning, warning=~p, frame=~p",
+                             [binary_to_list(Warning), Frame]).

--- a/src/seestar_session.erl
+++ b/src/seestar_session.erl
@@ -25,6 +25,8 @@
 -export([set_event_listener/2]).
 -export([perform/3, perform_async/3]).
 -export([prepare/2, execute/5, execute_async/5]).
+-export([new_batch_query/1, new_batch_execute/3]).
+-export([batch/4, batch_async/4]).
 
 %% gen_server exports.
 -export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2,
@@ -239,6 +241,25 @@ execute(Client, QueryID, Types, Values, Consistency) ->
 
 execute_async(Client, QueryID, Types, Values, Consistency) ->
     Req = #execute{id = QueryID, types = Types, values = Values, consistency = Consistency},
+    request(Client, Req, false).
+
+new_batch_query(Query) ->
+    #batch_query{query = Query}.
+
+new_batch_execute(QueryID, Types, Values) ->
+    #batch_execute{id=QueryID, types=Types, values=Values}.
+
+batch(Client, Type, Queries, Consistency) ->
+    Req = #batch{type = Type, queries = Queries, consistency = Consistency},
+    case request(Client, Req, true) of
+        #result{result = Result} ->
+            {ok, Result};
+        #error{} = Error ->
+            {error, Error}
+    end.
+
+batch_async(Client, Type, Queries, Consistency) ->
+    Req = #batch{type = Type, queries = Queries, consistency = Consistency},
     request(Client, Req, false).
 
 request(Client, Request, Sync) ->

--- a/src/seestar_types.erl
+++ b/src/seestar_types.erl
@@ -20,6 +20,7 @@
          encode_consistency/1, encode_string_map/1]).
 -export([decode_int/1, decode_short/1, decode_byte/1, decode_string/1, decode_uuid/1,
          decode_bytes/1, decode_short_bytes/1, decode_consistency/1,
+         decode_string_list/1,
          decode_string_multimap/1, decode_inet/1]).
 
 %% -------------------------------------------------------------------------

--- a/src/seestar_types.erl
+++ b/src/seestar_types.erl
@@ -15,8 +15,9 @@
 %%% @private
 -module(seestar_types).
 
--export([encode_short/1, encode_long_string/1, encode_string_list/1, encode_bytes/1,
-         encode_short_bytes/1, encode_consistency/1, encode_string_map/1]).
+-export([encode_int/1, encode_short/1, encode_long_string/1, encode_string_list/1,
+         encode_bytes/1, encode_short_bytes/1,
+         encode_consistency/1, encode_string_map/1]).
 -export([decode_int/1, decode_short/1, decode_byte/1, decode_string/1, decode_uuid/1,
          decode_bytes/1, decode_short_bytes/1, decode_consistency/1,
          decode_string_multimap/1, decode_inet/1]).

--- a/test/seestar_session_tests.erl
+++ b/test/seestar_session_tests.erl
@@ -9,50 +9,50 @@ session_test_() ->
          seestar_ccm:create(),
          seestar_ccm:start(),
          timer:sleep(500),
-         {ok, Pid} = seestar_session:start_link("localhost", 9042),
+         {ok, Pid, Client} = seestar_session:start_link("localhost", 9042),
          unlink(Pid),
-         Pid
+         Client
      end,
-     fun(Pid) ->
-         seestar_session:stop(Pid),
+     fun(Client) ->
+         seestar_session:stop(Client),
          seestar_ccm:remove()
      end,
-     [fun(Pid) -> {with, Pid, [fun test_schema_queries/1]} end,
-      fun(Pid) -> {with, Pid, [fun test_native_types/1]} end,
-      fun(Pid) -> {with, Pid, [fun test_collection_types/1]} end,
-      fun(Pid) -> {with, Pid, [fun test_counter_type/1]} end]}.
+     [fun(Client) -> {with, Client, [fun test_schema_queries/1]} end,
+      fun(Client) -> {with, Client, [fun test_native_types/1]} end,
+      fun(Client) -> {with, Client, [fun test_collection_types/1]} end,
+      fun(Client) -> {with, Client, [fun test_counter_type/1]} end]}.
 
-test_schema_queries(Pid) ->
+test_schema_queries(Client) ->
     Qry0 = "CREATE KEYSPACE seestar "
            "WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}",
-    {ok, Res0} = seestar_session:perform(Pid, Qry0, one),
+    {ok, Res0} = seestar_session:perform(Client, Qry0, one),
     ?assertEqual(schema_change, seestar_result:type(Res0)),
     ?assertEqual(<<"seestar">>, seestar_result:keyspace(Res0)),
     ?assertEqual(undefined, seestar_result:table(Res0)),
 
-    {error, Err0} = seestar_session:perform(Pid, Qry0, one),
+    {error, Err0} = seestar_session:perform(Client, Qry0, one),
     ?assertEqual(?ALREADY_EXISTS, seestar_error:code(Err0)),
     ?assertEqual(<<"seestar">>, seestar_error:keyspace(Err0)),
     ?assertEqual(undefined, seestar_error:table(Err0)),
 
     Qry1 = "USE seestar",
-    {ok, Res1} = seestar_session:perform(Pid, Qry1, one),
+    {ok, Res1} = seestar_session:perform(Client, Qry1, one),
     ?assertEqual(set_keyspace, seestar_result:type(Res1)),
     ?assertEqual(<<"seestar">>, seestar_result:keyspace(Res1)),
 
     Qry2 = "CREATE TABLE seestar_test_table (id int primary key, value text)",
-    {ok, Res2} = seestar_session:perform(Pid, Qry2, one),
+    {ok, Res2} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual(schema_change, seestar_result:type(Res2)),
     ?assertEqual(<<"seestar">>, seestar_result:keyspace(Res2)),
     ?assertEqual(<<"seestar_test_table">>, seestar_result:table(Res2)),
 
-    {error, Err1} = seestar_session:perform(Pid, Qry2, one),
+    {error, Err1} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual(?ALREADY_EXISTS, seestar_error:code(Err1)),
     ?assertEqual(<<"seestar">>, seestar_error:keyspace(Err1)),
     ?assertEqual(<<"seestar_test_table">>, seestar_error:table(Err1)).
 
-test_native_types(Pid) ->
-    create_keyspace(Pid, "seestar", 1),
+test_native_types(Client) ->
+    create_keyspace(Client, "seestar", 1),
     Qry0 = "CREATE TABLE seestar.has_all_types (
                 asciicol ascii,
                 bigintcol bigint,
@@ -71,13 +71,13 @@ test_native_types(Pid) ->
                 varintcol varint,
                 PRIMARY KEY(asciicol)
             )",
-    {ok, _} = seestar_session:perform(Pid, Qry0, one),
+    {ok, _} = seestar_session:perform(Client, Qry0, one),
     % test serialization.
     Qry1 = "INSERT INTO seestar.has_all_types (
                asciicol, bigintcol, blobcol, booleancol, decimalcol, doublecol, floatcol,
                inetcol, intcol, textcol, timestampcol, timeuuidcol, uuidcol, varcharcol, varintcol)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    {ok, Res1} = seestar_session:prepare(Pid, Qry1),
+    {ok, Res1} = seestar_session:prepare(Client, Qry1),
     QryID = seestar_result:query_id(Res1),
     Types = seestar_result:types(Res1),
     ?assertEqual([ascii, bigint, blob, boolean, decimal, double, float,
@@ -93,31 +93,31 @@ test_native_types(Pid) ->
             <<135,99,103,104,40,81,17,187,181,58,96,197,71,12,191,14>>,
             <<148,125,144,228,220,27,68,12,148,158,178,154,25,169,42,113>>,
             <<>>, 100000000000000000000000000],
-    {ok, _} = seestar_session:execute(Pid, QryID, Types, Row0, one),
-    {ok, _} = seestar_session:execute(Pid, QryID, Types, Row1, one),
+    {ok, _} = seestar_session:execute(Client, QryID, Types, Row0, one),
+    {ok, _} = seestar_session:execute(Client, QryID, Types, Row1, one),
     % test deserialization.
     Qry2 = "SELECT asciicol, bigintcol, blobcol, booleancol, decimalcol, doublecol, floatcol,
                    inetcol, intcol, textcol, timestampcol, timeuuidcol, uuidcol, varcharcol, varintcol
             FROM seestar.has_all_types",
-    {ok, Res2} = seestar_session:perform(Pid, Qry2, one),
+    {ok, Res2} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual(Types, seestar_result:types(Res2)),
     ?assertEqual([Row0, Row1], seestar_result:rows(Res2)).
 
-test_counter_type(Pid) ->
-    create_keyspace(Pid, "seestar", 1),
+test_counter_type(Client) ->
+    create_keyspace(Client, "seestar", 1),
     Qry0 = "CREATE TABLE seestar.has_counter_type (id int PRIMARY KEY, counter counter)",
-    {ok, _} = seestar_session:perform(Pid, Qry0, one),
+    {ok, _} = seestar_session:perform(Client, Qry0, one),
     Qry1 = "UPDATE seestar.has_counter_type SET counter = counter + ? WHERE id = ?",
-    {ok, Res1} = seestar_session:prepare(Pid, Qry1),
+    {ok, Res1} = seestar_session:prepare(Client, Qry1),
     QryID = seestar_result:query_id(Res1),
     Types = seestar_result:types(Res1),
-    [ {ok, _} = seestar_session:execute(Pid, QryID, Types, [C, 0], one) || C <- [ 1, -2, 3 ] ],
+    [ {ok, _} = seestar_session:execute(Client, QryID, Types, [C, 0], one) || C <- [ 1, -2, 3 ] ],
     Qry2 = "SELECT id, counter FROM seestar.has_counter_type WHERE id = 0",
-    {ok, Res2} = seestar_session:perform(Pid, Qry2, one),
+    {ok, Res2} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual([[0, 2]], seestar_result:rows(Res2)).
 
-test_collection_types(Pid) ->
-    create_keyspace(Pid, "seestar", 1),
+test_collection_types(Client) ->
+    create_keyspace(Client, "seestar", 1),
     Qry0 = "CREATE TABLE seestar.has_collection_types (
                 id int,
                 mapcol map<text,blob>,
@@ -125,19 +125,19 @@ test_collection_types(Pid) ->
                 listcol list<boolean>,
                 PRIMARY KEY(id)
             )",
-    {ok, _} = seestar_session:perform(Pid, Qry0, one),
+    {ok, _} = seestar_session:perform(Client, Qry0, one),
     Qry1 = "INSERT INTO seestar.has_collection_types (id, mapcol, setcol, listcol) VALUES (?, ?, ?, ?)",
-    {ok, Res1} = seestar_session:prepare(Pid, Qry1),
+    {ok, Res1} = seestar_session:prepare(Client, Qry1),
     QryID = seestar_result:query_id(Res1),
     Types = seestar_result:types(Res1),
     Row0 = [0, null, null, null],
     Row1 = [1, dict:from_list([{<<"k1">>, <<"v1">>}]), sets:from_list([1]), [true]],
     Row2 = [2, dict:from_list([{<<"k1">>, <<"v1">>}, {<<"k2">>, <<"v2">>}]), sets:from_list([1,2]), [true, false]],
-    [ {ok, _} = seestar_session:execute(Pid, QryID, Types, R, one) || R <- [Row0, Row1, Row2] ],
+    [ {ok, _} = seestar_session:execute(Client, QryID, Types, R, one) || R <- [Row0, Row1, Row2] ],
     Qry2 = "SELECT id, mapcol, setcol, listcol FROM seestar.has_collection_types",
-    {ok, Res2} = seestar_session:perform(Pid, Qry2, one),
+    {ok, Res2} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual([Row1, Row0, Row2], seestar_result:rows(Res2)).
 
-create_keyspace(Pid, Name, RF) ->
+create_keyspace(Client, Name, RF) ->
     Qry = "CREATE KEYSPACE ~s WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': ~w}",
-    {ok, _} = seestar_session:perform(Pid, lists:flatten(io_lib:format(Qry, [Name, RF])), one).
+    {ok, _} = seestar_session:perform(Client, lists:flatten(io_lib:format(Qry, [Name, RF])), one).

--- a/test/seestar_session_tests.erl
+++ b/test/seestar_session_tests.erl
@@ -166,6 +166,7 @@ test_batch_queries(Client) ->
     B1 = seestar_session:new_batch_execute(QryID, Types, Row1),
     B2 = seestar_session:new_batch_execute(QryID, Types, Row2),
     {ok, _} = seestar_session:batch(Client, logged, [B1, B2], one),
+    {ok, _} = seestar_session:batch(Client, unlogged, [B1, B2], one),
     Qry2 = "SELECT name, password FROM seestar.user",
     {ok, Res3} = seestar_session:perform(Client, Qry2, one),
     ?assertEqual([Row1, Row2], lists:sort(seestar_result:rows(Res3))).

--- a/test/seestar_ssl_tests.erl
+++ b/test/seestar_ssl_tests.erl
@@ -6,6 +6,16 @@
 -export([]).
 
 ssl_test_() ->
+    case has_ccm() of
+        true ->
+            ssl_test_with_ccm();
+        false -> []
+    end.
+
+has_ccm() ->
+    os:cmd("whereis ccm") =/= "ccm:\n".
+
+ssl_test_with_ccm() ->
     {setup,
         fun() ->
             seestar_ccm:create(),

--- a/wait_for_cassandra.sh
+++ b/wait_for_cassandra.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+erl -eval 'try lists:map(fun(N) -> case gen_tcp:connect("127.0.0.1", 9042, [], 1000) of {error,econnrefused} -> io:format("Retry, n=~p~n", [N]), timer:sleep(1000); _ -> exit(normal) end end, lists:seq(1,60)) after init:stop(0) end.'

--- a/wait_for_cassandra.sh
+++ b/wait_for_cassandra.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
-erl -eval 'try lists:map(fun(N) -> case gen_tcp:connect("127.0.0.1", 9042, [], 1000) of {error,econnrefused} -> io:format("Retry, n=~p~n", [N]), timer:sleep(1000); _ -> init:stop(0) end end, lists:seq(1,60)) after init:stop(1) end.'
+# We cannot just connect to 127.0.0.1:9042 because Docker is very "smart" and
+# exposes ports before the service is ready
+IP=$(/usr/bin/docker inspect -f {{.NetworkSettings.IPAddress}} cassandra)
+echo "cassandra IP is $IP"
+erl -eval 'try lists:map(fun(N) -> case gen_tcp:connect("'"$IP"'", 9042, [], 1000) of {error,econnrefused} -> io:format("Retry, n=~p~n", [N]), timer:sleep(1000); Other -> io:format("~p", [Other]), init:stop(0) end end, lists:seq(1,60)) after init:stop(1) end.'

--- a/wait_for_cassandra.sh
+++ b/wait_for_cassandra.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-erl -eval 'try lists:map(fun(N) -> case gen_tcp:connect("127.0.0.1", 9042, [], 1000) of {error,econnrefused} -> io:format("Retry, n=~p~n", [N]), timer:sleep(1000); _ -> exit(normal) end end, lists:seq(1,60)) after init:stop(0) end.'
+erl -eval 'try lists:map(fun(N) -> case gen_tcp:connect("127.0.0.1", 9042, [], 1000) of {error,econnrefused} -> io:format("Retry, n=~p~n", [N]), timer:sleep(1000); _ -> init:stop(0) end end, lists:seq(1,60)) after init:stop(1) end.'


### PR DESCRIPTION
Changes:
- start_link returns `{ok, Pid, ConnectionHandle}`. ConnectionHandle is used to make queries. Basically, we need to have version to decode messages on the client side, so this handle is pid and version number.
- protocol selection between version 3 and 4. 
- Travis CI.

I think this PR is not ready to be merged yet, but if someone wants to access new versions of cassandra they can reuse my work. So, let's keep this PR listed on the repo.
